### PR TITLE
Store statement's property created & stored as DateTime instead of timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+master
+------
+
+* store statement's created and stored property as `\DateTime` instead of
+  `int` timestamp.
+
 0.4.0
 -----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,14 @@
 CHANGELOG
 =========
 
-master
-------
-
-* store statement's created and stored property as `\DateTime` instead of
-  `int` timestamp.
-
 0.4.0
 -----
 
 * made the package compatible with `3.x` releases of `ramsey/uuid`
 * allow `2.x` releases of the `php-xapi/model` package too
+* the created and stored properties of the internal mapping `Statement` class
+  are now instances of PHP's `\DateTime` class instead of integers representing
+  UNIX timestamps.
 
 0.3.0
 -----

--- a/src/Mapping/Statement.php
+++ b/src/Mapping/Statement.php
@@ -52,12 +52,12 @@ class Statement
     public $authority;
 
     /**
-     * @var int
+     * @var \DateTime|null
      */
     public $created;
 
     /**
-     * @var int
+     * @var \DateTime|null
      */
     public $stored;
 
@@ -84,8 +84,8 @@ class Statement
         $statement->verb = Verb::fromModel($model->getVerb());
         $statement->object = Object::fromModel($model->getObject());
 
-        if (null !== $model->getTimestamp()) {
-            $statement->created = $model->getTimestamp()->getTimestamp();
+        if (null !== $model->getCreated()) {
+            $statement->created = $model->getCreated();
         }
 
         if (null !== $result = $model->getResult()) {
@@ -134,11 +134,11 @@ class Statement
         }
 
         if (null !== $this->created) {
-            $created = new \DateTime('@'.$this->created);
+            $created = $this->created;
         }
 
         if (null !== $this->stored) {
-            $stored = new \DateTime('@'.$this->stored);
+            $stored = $this->stored;
         }
 
         if (null !== $this->context) {

--- a/src/Repository/StatementRepository.php
+++ b/src/Repository/StatementRepository.php
@@ -125,7 +125,7 @@ final class StatementRepository implements StatementRepositoryInterface
         }
 
         $mappedStatement = MappedStatement::fromModel($statement);
-        $mappedStatement->stored = time();
+        $mappedStatement->stored = new \DateTime();
 
         $this->repository->storeStatement($mappedStatement, $flush);
 


### PR DESCRIPTION
Since Doctrine supports handle of `\DateTime` instance, let's just use that.